### PR TITLE
Update grafana image to 8.0.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - grafana
 
   grafana:
-    image: grafana/grafana:7.3.6
+    image: grafana/grafana:8.0.6
     ports:
       - 3000:3000
     networks:


### PR DESCRIPTION
Grafana version 7 does not have Grafana Live push endpoint. Following the tutorial here: (https://grafana.com/tutorials/stream-metrics-from-telegraf-to-grafana/), Grafana responds 404 to Telegraf request's.   
Grafana version 8 has this endpoint and should save people time looking it up.