### PR TITLE
enabling new alerting simplified routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - grafana
 
   grafana:
-    image: grafana/grafana:10.3.0
+    image: grafana/grafana:10.4.0
     ports:
       - 3000:3000
     networks:
@@ -46,6 +46,7 @@ services:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_BASIC_ENABLED=false
+      - GF_FEATURE_TOGGLES_ENABLE=alertingSimplifiedRouting
     volumes:
       - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
 


### PR DESCRIPTION
**what is this feature**?:

- Enables the [new alerting simplified routing feature](https://grafana.com/docs/grafana/next/alerting/alerting-rules/create-grafana-managed-rule/#configure-notifications-simplified) via docker-compose env variable

This is a very convenient feature to have in our tutorial, because it centralizes the config of both contact point and notification policy from the alert rule menu itself

Note: (atm simplified routing is behind a feature flag. However. it is progressively being released in Cloud free tier accounts). So, it is reasonable to showcase a feature that new users will have available if they opt for Grafana Cloud.
 
- Also updates Grafana image to `grafana/grafana:10.4.0` , so the feature becomes available.




**why is it needed**?: 

