### PR TITLE
update grafana version and enable feature flag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - grafana
 
   grafana:
-    image: grafana/grafana:11.0.0
+    image: grafana/grafana:11.3.0
     ports:
       - 3000:3000
     networks:
@@ -46,7 +46,7 @@ services:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin # grants admin role to anonymous access
       - GF_AUTH_ANONYMOUS_ENABLED=true # removes login 1/2
       - GF_AUTH_BASIC_ENABLED=false # removes login 2/2
-      - GF_FEATURE_TOGGLES_ENABLE=alertingSimplifiedRouting
+      - GF_FEATURE_TOGGLES_ENABLE=alertingSimplifiedRouting,alertingQueryAndExpressionsStepMode
     volumes:
       - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
 


### PR DESCRIPTION
## what's this PR about?

Enables the new **Simplified query section** for OSS users that take the **Alerting Get started** tutorial, and the **Grafana fundamentals** tutorial. 

- Upgrades the Grafana version to **11.3.0** 
- Enables the feature flag `alertingQueryAndExpressionsStepMode` 

NOTE: do not merge before the public release (October 22nd) 