### PR TITLE
add test data to provisioning file

### DIFF
--- a/grafana/provisioning/datasources/datasources.yaml
+++ b/grafana/provisioning/datasources/datasources.yaml
@@ -9,3 +9,7 @@ datasources:
     basicAuth: false
     isDefault: true
     editable: true
+  - name: TestData
+    type: testdata
+    access: proxy
+    orgId: 1


### PR DESCRIPTION
- Includes the TestData data source in the provisioning file to save users from manually adding it when following along with different tutorials.