### PR TITLE
tutorial-env:update grafana version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - grafana
 
   grafana:
-    image: grafana/grafana:11.3.0
+    image: grafana/grafana:12.0.1
     ports:
       - 3000:3000
     networks:
@@ -46,7 +46,6 @@ services:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin # grants admin role to anonymous access
       - GF_AUTH_ANONYMOUS_ENABLED=true # removes login 1/2
       - GF_AUTH_BASIC_ENABLED=false # removes login 2/2
-      - GF_FEATURE_TOGGLES_ENABLE=alertingSimplifiedRouting,alertingQueryAndExpressionsStepMode
     volumes:
       - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
 


### PR DESCRIPTION
Upgrading the Grafana version so the UI matches the new alert rule form in the Get started with Grafana Alerting tutorials.