### PR TITLE
remove version attribute from docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 networks:
   grafana:
 


### PR DESCRIPTION
Remove the `version` attribute from the `docker-compose.yml` file since it is now deprecated.